### PR TITLE
Try the 'apple color emoji' typeface first

### DIFF
--- a/src/svg.js
+++ b/src/svg.js
@@ -9,7 +9,7 @@ module.exports = `<?xml version="1.0" standalone="no"?>
       </linearGradient>
     </defs>
     <rect fill="url(#avatar)" x="0" y="0" width="$WIDTH" height="$HEIGHT"/>
-    <text x="50%" y="50%" alignment-baseline="central" dominant-baseline="middle" text-anchor="middle" fill="#fff" font-family="sans-serif" font-size="$FONTSIZE" font-weight="bold">$TEXT</text>
+    <text x="50%" y="50%" alignment-baseline="central" dominant-baseline="middle" text-anchor="middle" fill="#fff" font-family="apple color emoji, sans-serif" font-size="$FONTSIZE" font-weight="bold">$TEXT</text>
   </g>
 </svg>
 `


### PR DESCRIPTION
This lets the browser first try to render with the `apple color emoji` typeface before falling back to `sans-serif`. 👍